### PR TITLE
removed location reload on fetch error

### DIFF
--- a/actor.js
+++ b/actor.js
@@ -109,7 +109,7 @@ function fetchActorProfile(name, surname) {
         })
 	        .catch((err => {
                 console.log(err)
-                location.reload()}));
+            }));
  }
 
  function renderFilms(movie) {


### PR DESCRIPTION
As the first API is broken, this will stop the broweser from continuously refreshing